### PR TITLE
[#30][BE] OAuth2 + JWT 구현 완료

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,9 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	//JWT Dependency
-	compileOnly("io.jsonwebtoken:jjwt-api:0.11.2")
-	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
-	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
+	implementation group: 'com.auth0', name: 'java-jwt', version: '3.16.0'
+
 
 	// modelmapper
 	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'

--- a/backend/src/main/java/com/baedal/monolithic/domain/account/entity/Account.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/account/entity/Account.java
@@ -32,6 +32,8 @@ public class Account {
     private String email;
     private String tel;
     private String profile;
+    private String refreshToken;
+    private String password;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -47,5 +49,8 @@ public class Account {
         return role.getKey();
     }
 
+    public void updateRefreshToken(String refreshToken){
+        this.refreshToken = refreshToken;
+    }
 
 }

--- a/backend/src/main/java/com/baedal/monolithic/domain/account/entity/Role.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/account/entity/Role.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
 
+    GUEST("ROLE_GUEST", "가입 전 사용자"),
     USER("ROLE_USER", "일반 사용자"),
     OWNER("ROLE_OWNER", "사장님"),
     ADMIN("ROLE_ADMIN", "관리자");

--- a/backend/src/main/java/com/baedal/monolithic/domain/account/exception/AccountControllerAdvice.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/account/exception/AccountControllerAdvice.java
@@ -2,21 +2,17 @@ package com.baedal.monolithic.domain.account.exception;
 
 import com.baedal.monolithic.global.exception.ExceptionCode;
 import com.baedal.monolithic.global.exception.ExceptionResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class AccountControllerAdvice {
 
-
     @ExceptionHandler(AccountException.class)
     public ResponseEntity<ExceptionResponse> processValidationError(AccountException exception) {
         ExceptionCode exceptionCode = exception.getExceptionCode();
         return ResponseEntity.status(exceptionCode.getStatus()).body(new ExceptionResponse(exceptionCode));
     }
-
 
 }

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/application/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/application/CustomOAuth2UserService.java
@@ -36,9 +36,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         Account user = saveIfNewUser(socialId);
 
-        return new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
-                oAuth2User.getAttributes(),
-                userNameAttributeName);
+        return new UserPrincipal(user,
+                Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
+                oAuth2User.getAttributes());
     }
 
     private Account saveIfNewUser(String socialId) {
@@ -55,6 +55,5 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         Long userIdFromProvider = (Long) oAuth2User.getAttributes().get(userNameAttributeName);
         return registrationId + "_" + userIdFromProvider;
     }
-
 
 }

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/application/UserPrincipal.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/application/UserPrincipal.java
@@ -1,0 +1,78 @@
+package com.baedal.monolithic.domain.auth.application;
+
+import com.baedal.monolithic.domain.account.entity.Account;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import reactor.util.annotation.Nullable;
+
+import java.util.*;
+
+@Getter
+public class UserPrincipal implements OAuth2User, UserDetails {
+
+    private Account account;
+    private Set<GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public UserPrincipal(Account account, Set<GrantedAuthority> authorities,
+                          Map<String, Object> attributes) {
+        this.account = account;
+        this.authorities = authorities;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getPassword() {
+        return account.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(account.getId());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    @Override
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public <A> A getAttribute(String name) {
+        return (A) attributes.get(name);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(account.getEmail());
+    }
+}

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/exception/JwtAccessDeniedHandler.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/exception/JwtAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.baedal.monolithic.domain.auth.exception;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/exception/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/exception/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.baedal.monolithic.domain.auth.exception;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
+    }
+}

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/exception/OAuthProcessingException.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/exception/OAuthProcessingException.java
@@ -1,0 +1,8 @@
+package com.baedal.monolithic.domain.auth.exception;
+
+public class OAuthProcessingException extends RuntimeException {
+
+    public OAuthProcessingException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/util/CookieAuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/util/CookieAuthorizationRequestRepository.java
@@ -1,0 +1,50 @@
+package com.baedal.monolithic.domain.auth.util;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class CookieAuthorizationRequestRepository implements AuthorizationRequestRepository {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtil.deleteCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtil.deleteCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS);
+        }
+
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtil.deleteCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtil.deleteCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+}

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/util/CookieUtil.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/util/CookieUtil.java
@@ -1,0 +1,51 @@
+package com.baedal.monolithic.domain.auth.util;
+
+import org.springframework.util.SerializationUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtil {
+    public static void addCookie(HttpServletResponse response,
+                                 String cookieKey,
+                                 String cookieValue,
+                                 int maxAge) {
+        Cookie cookie = new Cookie(cookieKey, cookieValue);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletResponse response,
+                             String cookieKey) {
+        Cookie cookie = new Cookie(cookieKey, null);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+    public static Optional<Cookie> getCookie(HttpServletRequest request,
+                          String cookieKey) {
+        Cookie[] cookies = request.getCookies();
+
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(cookieKey)) {
+                return Optional.of(cookie);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder()
+                        .decode(cookie.getValue())));
+    }
+}

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/util/JwtAuthenticationProcessingFilter.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/util/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,87 @@
+package com.baedal.monolithic.domain.auth.util;
+
+import com.baedal.monolithic.domain.account.entity.Account;
+import com.baedal.monolithic.domain.account.exception.AccountException;
+import com.baedal.monolithic.domain.account.exception.AccountExceptionCode;
+import com.baedal.monolithic.domain.account.repository.AccountRepository;
+import com.baedal.monolithic.domain.auth.exception.OAuthProcessingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final AccountRepository accountRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String refreshToken = jwtProvider.extractRefreshTokenFromHeader(request)
+                .filter(jwtProvider::isTokenValid)
+                .orElse(null);
+
+        if (refreshToken != null) {
+            checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
+            return;
+        }
+
+        checkAccessTokenAndAuthentication(request);
+        filterChain.doFilter(request, response);
+
+    }
+
+//    @Transactional
+    public void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
+        String userId = jwtProvider.extractUserId(refreshToken)
+                .orElseThrow(() -> new OAuthProcessingException("토큰이 유효하지 않습니다."));
+
+        Account account = accountRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new AccountException(AccountExceptionCode.NO_USER));
+
+        if (!account.getRefreshToken().equals(refreshToken))
+            throw new OAuthProcessingException("RefreshToken not match");
+
+        jwtProvider.refreshAccessAndRefreshToken(response, userId);
+    }
+
+    public void checkAccessTokenAndAuthentication(HttpServletRequest request) {
+        log.info("checkAccessTokenAndAuthentication() 호출");
+        jwtProvider.extractAccessTokenFromHeader(request)
+                .filter(jwtProvider::isTokenValid)
+                .flatMap(jwtProvider::extractUserId)
+                .map(Long::valueOf)
+                .flatMap(accountRepository::findById)
+                .ifPresent(this::saveAuthentication);
+    }
+
+    public void saveAuthentication(Account myUser) {
+        UserDetails userDetails = User.builder()
+                .username(String.valueOf(myUser.getId()))
+                .password("")
+                .roles(myUser.getRole().name())
+                .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null,
+                        userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/util/JwtProvider.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/util/JwtProvider.java
@@ -1,8 +1,126 @@
 package com.baedal.monolithic.domain.auth.util;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.baedal.monolithic.domain.account.entity.Account;
+import com.baedal.monolithic.domain.account.exception.AccountException;
+import com.baedal.monolithic.domain.account.exception.AccountExceptionCode;
+import com.baedal.monolithic.domain.account.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
+import java.util.Optional;
+
+@RequiredArgsConstructor
 @Component
+@Slf4j
 public class JwtProvider {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.access.expiration}")
+    private int accessTokenExpirationPeriod;
+
+    @Value("${jwt.refresh.expiration}")
+    private int refreshTokenExpirationPeriod;
+
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+//    private final CookieUtil cookieUtil;
+
+    /**
+     * JWT의 Subject와 Claim으로 userId 사용 -> 클레임의 name을 "userId"으로 설정
+     * JWT의 헤더에 들어오는 값 : 'Authorization(Key) = Bearer {토큰} (Value)' 형식
+     */
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String USERID_CLAIM = "userId";
+    private static final String BEARER = "Bearer ";
+
+    private final AccountRepository accountRepository;
+    public String createAccessToken(String userId) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .withClaim(USERID_CLAIM, userId)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public String createRefreshToken(String userId) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .withClaim(USERID_CLAIM, userId)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public void refreshAccessAndRefreshToken(HttpServletResponse response, String userId) {
+        String accessToken = createAccessToken(userId);
+        String refreshToken = createRefreshToken(userId);
+
+        updateRefreshTokenInAccount(Long.valueOf(userId), refreshToken);
+
+        CookieUtil.addCookie(response, accessHeader, accessToken, accessTokenExpirationPeriod);
+        CookieUtil.addCookie(response, refreshHeader, refreshToken, refreshTokenExpirationPeriod);
+    }
+
+    public void updateRefreshTokenInAccount(Long userId, String refreshToken) {
+        Account account = accountRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(AccountExceptionCode.NO_USER));
+
+        account.updateRefreshToken(refreshToken);
+        accountRepository.save(account);
+    }
+
+    public Optional<String> extractRefreshTokenFromHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractAccessTokenFromHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractUserId(String token) {
+        try {
+            // 토큰 유효성 검사하는 데에 사용할 알고리즘이 있는 JWT verifier builder 반환
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+                    .build() // 반환된 빌더로 JWT verifier 생성
+                    .verify(token) // accessToken을 검증하고 유효하지 않다면 예외 발생
+                    .getClaim(USERID_CLAIM) // claim(Emial) 가져오기
+                    .asString());
+        } catch (Exception e) {
+            log.error("액세스 토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(secretKey))
+                    .build()
+                    .verify(token);
+            return true;
+        } catch (Exception e) {
+            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            return false;
+        }
+    }
+
 
 }

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/util/OAuth2FailureHandler.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/util/OAuth2FailureHandler.java
@@ -1,0 +1,50 @@
+package com.baedal.monolithic.domain.auth.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패!");
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+
+        String targetUrl = determineTargetUrl(request, exception);
+
+
+        cookieAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+
+    }
+
+    protected String determineTargetUrl(HttpServletRequest request, AuthenticationException exception) {
+        String targetUrl = CookieUtil
+                .getCookie(request, CookieAuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .orElse("/");
+
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
+    }
+
+
+}

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/util/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/util/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,62 @@
+package com.baedal.monolithic.domain.auth.util;
+
+import com.baedal.monolithic.domain.auth.application.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.transaction.Transactional;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        saveAccessAndRefreshToken(response, authentication);
+
+        clearAuthenticationAttributes(request, response);
+
+        String targetUrl = determineTargetUrl(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+
+    }
+
+    @Override
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
+        String targetUrl = CookieUtil
+                .getCookie(request, CookieAuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .orElse(getDefaultTargetUrl());
+
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .build().toUriString();
+    }
+
+    protected void saveAccessAndRefreshToken(HttpServletResponse response, Authentication authentication) {
+        UserPrincipal userDetails = (UserPrincipal) authentication.getPrincipal();
+        String userId = userDetails.getUsername();
+
+        jwtProvider.refreshAccessAndRefreshToken(response, userId);
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        cookieAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+}

--- a/backend/src/main/java/com/baedal/monolithic/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/baedal/monolithic/global/config/SecurityConfig.java
@@ -1,13 +1,18 @@
 package com.baedal.monolithic.global.config;
 
+import com.baedal.monolithic.domain.account.repository.AccountRepository;
+import com.baedal.monolithic.domain.account.repository.AddressRepository;
 import com.baedal.monolithic.domain.auth.application.CustomOAuth2UserService;
+import com.baedal.monolithic.domain.auth.exception.JwtAccessDeniedHandler;
+import com.baedal.monolithic.domain.auth.exception.JwtAuthenticationEntryPoint;
+import com.baedal.monolithic.domain.auth.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -19,26 +24,48 @@ import java.util.Arrays;
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler customAuthenticationSuccessHandler;
+    private final OAuth2FailureHandler customAuthenticationFailureHandler;
+    private final JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter;
+    private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
+                .formLogin().disable()
                 .httpBasic().disable()
+                .csrf().disable()
                 .cors()
                 .and()
-                    .csrf().disable()
                     .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                     .authorizeRequests()
-//                    .antMatchers("/stores/**").authenticated()
-                    .antMatchers("/*").permitAll()
+//                .antMatchers("/oauth2").permitAll()
+                    .anyRequest().authenticated()
                 .and()
                     .logout()
                         .logoutSuccessUrl("/")
                 .and()
                     .oauth2Login()
-                        .userInfoEndpoint()
-                    .userService(customOAuth2UserService);
+                    .authorizationEndpoint()
+                .authorizationRequestRepository(cookieAuthorizationRequestRepository)
+                .and()
+                .redirectionEndpoint()
+                .and()
+                .userInfoEndpoint()
+                .userService(customOAuth2UserService)
+                .and()
+                .successHandler(customAuthenticationSuccessHandler)
+                .failureHandler(customAuthenticationFailureHandler);
+
+        http.exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)	// 401
+                .accessDeniedHandler(jwtAccessDeniedHandler);
+
+        http.addFilterBefore(jwtAuthenticationProcessingFilter, UsernamePasswordAuthenticationFilter.class);
+
     }
 
     @Bean
@@ -50,5 +77,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
+
+
+//    public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
+//        return new JwtAuthenticationProcessingFilter(jwtProvider, accountRepository);
+//    }
 
 }


### PR DESCRIPTION
- 모든 경우에 대한 테스트는 해야함
- socialId가 아닌 userId로 token 및 authentication 생성
- OAuth2User 는 추후에 일반 회원가입에 대한 확장성을 위해 OAuth2User과 UserDetails를 상속받는 UserPricipal로 바꿈
- 클라이언트로부터 콜백 uri로 redirect_uri 파라미터가 있다면, 인증 후 해당 파라미터로 리다이렉트
- 로그인 성공 여부에 상관없이 저장한 redirect_uri는 삭제됨
- 리프레시토큰으로 액세스토큰을 재생성할 때 리프레시토큰도 함께 재생성 됨.

추후에 해야 할 일
- accessToken 이 만료되었을 때, refresh Token을 달라고 클라이언트한테 요청.
- refresh를 다시 받을 땐, redirect_uri 가 캐시에서 삭제되지 않음.