### PR TITLE
[BE] feat: ignoring을 이용한 시큐리티 필터 제외

### DIFF
--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/exception/ExceptionHandlerFilter.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/exception/ExceptionHandlerFilter.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.jwt.JwtException;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -19,8 +18,8 @@ import java.io.IOException;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
     private final ObjectMapper objectMapper;
     @Override
     protected void doFilterInternal(

--- a/backend/src/main/java/com/baedal/monolithic/domain/auth/util/JwtAuthenticationProcessingFilter.java
+++ b/backend/src/main/java/com/baedal/monolithic/domain/auth/util/JwtAuthenticationProcessingFilter.java
@@ -1,26 +1,14 @@
 package com.baedal.monolithic.domain.auth.util;
 
-import com.auth0.jwt.exceptions.TokenExpiredException;
-import com.baedal.monolithic.domain.account.entity.Account;
-import com.baedal.monolithic.domain.account.exception.AccountException;
-import com.baedal.monolithic.domain.account.exception.AccountExceptionCode;
-import com.baedal.monolithic.domain.account.repository.AccountRepository;
 import com.baedal.monolithic.domain.auth.application.AuthService;
 import com.baedal.monolithic.domain.auth.dto.AuthDto;
-import com.baedal.monolithic.domain.auth.exception.AuthStatusCode;
-import com.baedal.monolithic.domain.auth.exception.OAuthProcessingException;
-import com.baedal.monolithic.global.exception.ExceptionResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -30,7 +18,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @RequiredArgsConstructor
-@Component
 @Slf4j
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
@@ -40,7 +27,6 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-
 
 //            String refreshToken = jwtProvider.extractRefreshTokenFromHeader(request)
 //                    .filter(jwtProvider::isTokenValid)


### PR DESCRIPTION
- 기존의 방법은 인증이 필요없는 서비스들도 시큐리티 필터에 들어가는 방식이었음. ignoring을 이용해서 아예 들어가지 않도록 변경
- 기존에는 필터를 빈등록을 해서 시큐리티필터를 안타도 커스텀필터는 타게 되어있었음. 커스텀 필터에서 @Component를 삭제하고 config에서는 직접 필터를 생성해서 넣어줌으로써 커스텀필터에도 들어가지 않도록 함